### PR TITLE
Convert ENV values to string when calling 'setenv'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Serializes ENV values when calling `setenv`.
+
 ## [0.1.0] - 2017-10-19
 
 Initial release.

--- a/src/resty/execvp.lua
+++ b/src/resty/execvp.lua
@@ -45,7 +45,7 @@ local function execvp(filename, args, env)
   local cargv = ffi.cast("char *const*", argv)
 
   for name, value in pairs(env or {}) do
-    assert(setenv(name, value))
+    assert(setenv(name, tostring(value)))
   end
 
   C.execvp(filename, cargv)


### PR DESCRIPTION
This allows us to send, for example, integers in `env` when calling `execvp`.